### PR TITLE
feat: impl `ph` function

### DIFF
--- a/src/__internal__/Ph.ts
+++ b/src/__internal__/Ph.ts
@@ -1,3 +1,4 @@
+import { getAllFiles } from './getAllFiles';
 import { filter, join, map } from './iterableHelpers';
 import fs from 'node:fs';
 
@@ -32,11 +33,11 @@ export class Ph implements PathGen {
   ) {}
 
   setInputPath(path: string): Ph {
-    return new Ph(path, this.outputPath, this.paths);
+    return new Ph(path, this.outputPath, getAllFiles(path));
   }
 
   setOutputPath(path: string): Ph {
-    return new Ph(this.inputPath, path, this.paths);
+    return new Ph(this.inputPath, path, getAllFiles(path));
   }
 
   map(callbackFn: (path: string) => string): Ph {

--- a/src/__internal__/Ph.ts
+++ b/src/__internal__/Ph.ts
@@ -12,7 +12,7 @@ export interface PathGen<A> {
   /**
    * Directory path to generate types from
    * @example
-   * ```md
+   * ```typescript
    * './public/assets'
    */
   inputPath: string;
@@ -20,7 +20,7 @@ export interface PathGen<A> {
   /**
    * File path where generated type definition will be written
    * @example
-   * ```md
+   * ```typescript
    * './types/pathsType.ts'
    * ```
    */
@@ -32,7 +32,7 @@ export interface PathGen<A> {
   config: Config;
 
   /**
-   * Iterable of paths generated from inputPath
+   * Iterable of paths generated from `inputPath`
    */
   paths: Iterable<A>;
 
@@ -53,41 +53,48 @@ export interface PathGen<A> {
 
   /**
    * Transforms each path using the provided callback function
-   * @note Lazily evaluated until `write()` is called
+   * @note **Lazily evaluated** until `write()` is called
    * @note Use `typed` tagged template function for object type transformation
    * @example
    * ```typescript
    * const paths = ph('./input', './output.ts')
-   *  .map(path => path.toUpperCase()) // literal type, not consumed
+   *  .map(path => path.toUpperCase()) // literal type, iterable is not consumed
    *  .map(path => typed`{
    *     path: ${path}
-   *   }`) // Object type, still not consumed
+   *   }`) // object type, iterable is still not consumed
    *
-   * paths.write() // consumed
+   * paths.write() // iterable is consumed
    * ```
    */
   map<B>(callbackFn: (path: A) => B): PathGen<B>;
 
   /**
    * Filters paths based on the provided callback function
-   * @note Lazily evaluated until `write()` is called
+   * @note **Lazily evaluated** until `write()` is called
    * @example
    * ```typescript
-   * const paths = ph('./input', './output.ts') // not consumed
+   * const paths = ph('./input', './output.ts') // iterable is not consumed
    *  .filter(path => path.endsWith('.ts'))
    *
-   * paths.write() // consumed
+   * paths.write() // iterable is consumed
    * ```
    */
   filter(callbackFn: (path: A) => boolean): PathGen<A>;
 
   /**
    * `Asynchronously` writes the generated type definition to the output file
+   *
+   * Calling this method consumes the iterable.
+   * @param formatter Function to format the generated code before writing (e.g. Prettier)
    */
   write(formatter?: (code: string) => string): Promise<void>;
 
   /**
    * `Synchronously` writes the generated type definition to the output file
+   *
+   * Calling this method consumes the iterable.
+   * @param formatter Function to format the generated code before writing (e.g. Prettier)
+   *
    */
   writeSync(formatter?: (code: string) => string): Ph<A>;
 }

--- a/src/__internal__/Ph.ts
+++ b/src/__internal__/Ph.ts
@@ -72,7 +72,7 @@ export class Ph<A> implements PathGen<A> {
     return new Ph(this.inputPath, this.outputPath, this.paths, config);
   }
 
-  public createUnionType() {
+  public _createUnionType() {
     const PREFIX = `${this.config.annotation}export type ${this.config.typeName} = `;
 
     const reduced = join(
@@ -89,13 +89,13 @@ export class Ph<A> implements PathGen<A> {
   }
 
   public async write(formatter?: (code: string) => string): Promise<void> {
-    const code = this.createUnionType();
+    const code = this._createUnionType();
 
     await fs.promises.writeFile(this.outputPath, formatter?.(code) ?? code);
   }
 
   public writeSync(formatter?: (code: string) => string): Ph<A> {
-    const code = this.createUnionType();
+    const code = this._createUnionType();
 
     fs.writeFileSync(this.outputPath, formatter?.(code) ?? code);
 

--- a/src/__internal__/Ph.ts
+++ b/src/__internal__/Ph.ts
@@ -1,0 +1,80 @@
+import { filter, join, map } from './iterableHelpers';
+import fs from 'node:fs';
+
+export interface Config {
+  typeName: string;
+  description: string;
+}
+
+export interface PathGen {
+  inputPath: string;
+  outputPath: string;
+  config: Config;
+  paths: Iterable<string>;
+  setInputPath(path: string): PathGen;
+  setOutputPath(path: string): PathGen;
+  setConfig(config: Config | ((prevConfig: Config) => Config)): void;
+  map(callbackFn: (path: string) => string): PathGen;
+  filter(callbackFn: (path: string) => boolean): PathGen;
+  write(formatter?: (code: string) => string): Promise<void>;
+}
+
+export class Ph implements PathGen {
+  private _config: Config = {
+    typeName: '',
+    description: '',
+  };
+
+  constructor(
+    public inputPath: string,
+    public outputPath: string,
+    public paths: Iterable<string>,
+  ) {}
+
+  setInputPath(path: string): Ph {
+    return new Ph(path, this.outputPath, this.paths);
+  }
+
+  setOutputPath(path: string): Ph {
+    return new Ph(this.inputPath, path, this.paths);
+  }
+
+  map(callbackFn: (path: string) => string): Ph {
+    return new Ph(this.inputPath, this.outputPath, map(callbackFn, this.paths));
+  }
+
+  filter(callbackFn: (path: string) => boolean): Ph {
+    return new Ph(
+      this.inputPath,
+      this.outputPath,
+      filter(callbackFn, this.paths),
+    );
+  }
+
+  get config() {
+    return this._config;
+  }
+
+  public setConfig(config: Config | ((prevConfig: Config) => Config)) {
+    if (typeof config === 'function') {
+      this._config = config(this._config);
+
+      return;
+    }
+
+    this._config = config;
+  }
+
+  async write(formatter?: (code: string) => string): Promise<void> {
+    const DEFAULT_TYPE_NAME = 'PathType';
+    const PREFIX = `export type ${this._config.typeName || DEFAULT_TYPE_NAME} = `;
+
+    const reduced = join(
+      ' | ',
+      map((path) => `'${path}'`, this.paths),
+    );
+    const code = PREFIX + reduced;
+
+    await fs.promises.writeFile(this.outputPath, formatter?.(code) ?? code);
+  }
+}

--- a/src/__internal__/Ph.ts
+++ b/src/__internal__/Ph.ts
@@ -27,7 +27,7 @@ export class Ph<A> implements PathGen<A> {
     public paths: Iterable<A>,
     public config: Config = {
       description: '',
-      typeName: '',
+      typeName: 'PathType',
     },
   ) {}
 
@@ -40,7 +40,7 @@ export class Ph<A> implements PathGen<A> {
   }
 
   map<B>(callbackFn: (path: A) => B): Ph<B> {
-    return new Ph<B>(
+    return new Ph(
       this.inputPath,
       this.outputPath,
       map(callbackFn, this.paths),
@@ -66,6 +66,7 @@ export class Ph<A> implements PathGen<A> {
         config(this.config),
       );
     }
+
     return new Ph(this.inputPath, this.outputPath, this.paths, config);
     }
 

--- a/src/__internal__/Ph.ts
+++ b/src/__internal__/Ph.ts
@@ -19,6 +19,7 @@ export interface PathGen<A> {
   map<B>(callbackFn: (path: A) => B): PathGen<B>;
   filter(callbackFn: (path: A) => boolean): PathGen<A>;
   write(formatter?: (code: string) => string): Promise<void>;
+  writeSync(formatter?: (code: string) => string): Ph<A>;
 }
 
 export class Ph<A> implements PathGen<A> {
@@ -32,15 +33,15 @@ export class Ph<A> implements PathGen<A> {
     },
   ) {}
 
-  setInputPath(path: string): Ph<string> {
+  public setInputPath(path: string): Ph<string> {
     return new Ph(path, this.outputPath, getAllFiles(path), this.config);
   }
 
-  setOutputPath(path: string): Ph<A> {
+  public setOutputPath(path: string): Ph<A> {
     return new Ph(this.inputPath, path, this.paths, this.config);
   }
 
-  map<B>(callbackFn: (path: A) => B): Ph<B> {
+  public map<B>(callbackFn: (path: A) => B): Ph<B> {
     return new Ph(
       this.inputPath,
       this.outputPath,
@@ -49,7 +50,7 @@ export class Ph<A> implements PathGen<A> {
     );
   }
 
-  filter(callbackFn: (path: A) => boolean): Ph<A> {
+  public filter(callbackFn: (path: A) => boolean): Ph<A> {
     return new Ph(
       this.inputPath,
       this.outputPath,
@@ -87,9 +88,17 @@ export class Ph<A> implements PathGen<A> {
     return code;
   }
 
-  async write(formatter?: (code: string) => string): Promise<void> {
+  public async write(formatter?: (code: string) => string): Promise<void> {
     const code = this.createUnionType();
 
     await fs.promises.writeFile(this.outputPath, formatter?.(code) ?? code);
+  }
+
+  public writeSync(formatter?: (code: string) => string): Ph<A> {
+    const code = this.createUnionType();
+
+    fs.writeFileSync(this.outputPath, formatter?.(code) ?? code);
+
+    return new Ph(this.inputPath, this.outputPath, this.paths, this.config);
   }
 }

--- a/src/__internal__/Ph.ts
+++ b/src/__internal__/Ph.ts
@@ -56,14 +56,14 @@ export class Ph implements PathGen {
     return this._config;
   }
 
-  public setConfig(config: Config | ((prevConfig: Config) => Config)) {
+  public setConfig(config: Config | ((prevConfig: Config) => Config)): Ph {
     if (typeof config === 'function') {
       this._config = config(this._config);
-
-      return;
+    } else {
+      this._config = config;
     }
 
-    this._config = config;
+    return this;
   }
 
   async write(formatter?: (code: string) => string): Promise<void> {

--- a/src/__internal__/Ph.ts
+++ b/src/__internal__/Ph.ts
@@ -9,16 +9,86 @@ export interface Config {
 }
 
 export interface PathGen<A> {
+  /**
+   * Directory path to generate types from
+   * @example
+   * ```md
+   * './public/assets'
+   */
   inputPath: string;
+
+  /**
+   * File path where generated type definition will be written
+   * @example
+   * ```md
+   * './types/pathsType.ts'
+   * ```
+   */
   outputPath: string;
+
+  /**
+   * Configuration for type generation
+   */
   config: Config;
+
+  /**
+   * Iterable of paths generated from inputPath
+   */
   paths: Iterable<A>;
+
+  /**
+   * Sets a new input directory path and change paths to new input dir iterable
+   */
   setInputPath(path: string): PathGen<string>;
+
+  /**
+   * Sets a new output file path
+   */
   setOutputPath(path: string): PathGen<A>;
+
+  /**
+   * Updates the configuration for type generation
+   */
   setConfig(config: Config | ((prevConfig: Config) => Config)): void;
+
+  /**
+   * Transforms each path using the provided callback function
+   * @note Lazily evaluated until `write()` is called
+   * @note Use `typed` tagged template function for object type transformation
+   * @example
+   * ```typescript
+   * const paths = ph('./input', './output.ts')
+   *  .map(path => path.toUpperCase()) // literal type, not consumed
+   *  .map(path => typed`{
+   *     path: ${path}
+   *   }`) // Object type, still not consumed
+   *
+   * paths.write() // consumed
+   * ```
+   */
   map<B>(callbackFn: (path: A) => B): PathGen<B>;
+
+  /**
+   * Filters paths based on the provided callback function
+   * @note Lazily evaluated until `write()` is called
+   * @example
+   * ```typescript
+   * const paths = ph('./input', './output.ts') // not consumed
+   *  .filter(path => path.endsWith('.ts'))
+   *
+   * paths.write() // consumed
+   * ```
+   */
   filter(callbackFn: (path: A) => boolean): PathGen<A>;
+
+  /**
+   * `Asynchronously` writes the generated type definition to the output file
+   */
   write(formatter?: (code: string) => string): Promise<void>;
+
+  /**
+   * `Synchronously` writes the generated type definition to the output file
+   */
   writeSync(formatter?: (code: string) => string): Ph<A>;
 }
 

--- a/src/__internal__/__tests__/Ph.test.ts
+++ b/src/__internal__/__tests__/Ph.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Ph, type Config } from '../Ph';
+import fs from 'node:fs';
+import { isIterable } from '../iterableHelpers';
+
+vi.mock('node:fs', () => ({
+  default: {
+    promises: {
+      writeFile: vi.fn(),
+    },
+  },
+}));
+
+describe('Ph', () => {
+  const INPUT_DIRECTORY_PATH = './src/__internal__/__tests__/__assets__';
+  const OUTPUT_FILE_PATH = './src/__tests__/foo.ts';
+
+  const iterable = [
+    './src/__internal__/__tests__/__assets__/index.md',
+    './src/__internal__/__tests__/__assets__/foo/index.tsx',
+    './src/__internal__/__tests__/__assets__/bar/index.ts',
+  ] as const;
+
+  describe('Path Setters', () => {
+    it('should create new instance with updated input path', () => {
+      const ph = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable);
+
+      const newInstance = ph.setInputPath('/new-input');
+
+      expect(newInstance).not.toBe(ph);
+      expect(newInstance.inputPath).toBe('/new-input');
+      expect(newInstance.outputPath).toBe(OUTPUT_FILE_PATH);
+    });
+
+    it('should create new instance with updated output path', () => {
+      const ph = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable);
+      const newInstance = ph.setOutputPath('/new-output');
+
+      expect(newInstance).not.toBe(ph);
+      expect(newInstance.inputPath).toBe(INPUT_DIRECTORY_PATH);
+      expect(newInstance.outputPath).toBe('/new-output');
+    });
+  });
+
+  describe('setConfig', () => {
+    it('should update config with object', () => {
+      const ph = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable);
+      const newConfig = { typeName: 'Test', description: 'Test Description' };
+
+      ph.setConfig(newConfig);
+      expect(ph.config).toEqual(newConfig);
+    });
+
+    it('should update config with callback function', () => {
+      const instance = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable);
+      const configCallback = (prevConfig: Config) => ({
+        ...prevConfig,
+        typeName: 'Updated',
+      });
+
+      instance.setConfig(configCallback);
+      expect(instance.config.typeName).toBe('Updated');
+    });
+  });
+
+  describe('map', () => {
+    it('transforms paths using provided callback', () => {
+      const cb = (path: string) => path.toUpperCase();
+
+      const ph = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable).map(
+        cb,
+      );
+
+      expect(ph instanceof Ph).toBeTruthy();
+      expect(isIterable(ph.paths)).toBeTruthy();
+      expect(ph.paths[Symbol.iterator]().next().value).toBe(cb(iterable[0]));
+    });
+  });
+
+  describe('filter', () => {
+    it('excludes paths not matching predicate', () => {
+      const cb = (path: string) => path.endsWith('.tsx');
+
+      const ph = new Ph(
+        INPUT_DIRECTORY_PATH,
+        OUTPUT_FILE_PATH,
+        iterable,
+      ).filter(cb);
+
+      expect(ph instanceof Ph).toBeTruthy();
+      expect(isIterable(ph.paths)).toBeTruthy();
+      expect(ph.paths[Symbol.iterator]().next().value).toBe(iterable[1]);
+    });
+  });
+
+  describe('write', () => {
+    it('should write file with default formatting', async () => {
+      const instance = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable);
+      await instance.write();
+
+      const expectedContent = `export type PathType = ${iterable.map((path) => `'${path}'`).join(' | ')}`;
+
+      expect(fs.promises.writeFile).toHaveBeenCalledWith(
+        OUTPUT_FILE_PATH,
+        expectedContent,
+      );
+    });
+
+    it('should write file with custom formatter', async () => {
+      const instance = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable);
+      const formatter = (code: string) => code.toLowerCase();
+      await instance.write(formatter);
+
+      const expectedContent = `export type PathType = ${iterable
+        .map((path) => `'${path}'`)
+        .join(' | ')
+        .toLowerCase()}`;
+
+      expect(fs.promises.writeFile).toHaveBeenCalledWith(
+        OUTPUT_FILE_PATH,
+        expectedContent,
+      );
+    });
+  });
+});

--- a/src/__internal__/__tests__/Ph.test.ts
+++ b/src/__internal__/__tests__/Ph.test.ts
@@ -101,6 +101,33 @@ describe('Ph', () => {
     });
   });
 
+  describe('Lazy Evaluation', () => {
+    it('should evaluate operations lazily when chaining filter and map', () => {
+      const operations: string[] = [];
+
+      const ph = new Ph('input', 'output.ts', ['path1', 'path2', 'path3'])
+        .filter((path) => {
+          operations.push(`filter: ${path}`);
+          return path.includes('2');
+        })
+        .map((path) => {
+          operations.push(`map: ${path}`);
+          return path.toUpperCase();
+        });
+
+      expect(operations).toHaveLength(0);
+
+      ph.createUnionType();
+
+      expect(operations).toEqual([
+        'filter: path1',
+        'filter: path2',
+        'map: path2',
+        'filter: path3',
+      ]);
+    });
+  });
+
   describe('createUnionType', () => {
     it('should generate valid type definition without map transformation', () => {
       const code = new Ph(

--- a/src/__internal__/__tests__/Ph.test.ts
+++ b/src/__internal__/__tests__/Ph.test.ts
@@ -6,6 +6,7 @@ import { typed } from '../typed';
 
 vi.mock('node:fs', () => ({
   default: {
+    writeFileSync: vi.fn(),
     promises: {
       writeFile: vi.fn(),
     },
@@ -181,6 +182,46 @@ describe('Ph', () => {
         OUTPUT_FILE_PATH,
         expectedContent,
       );
+    });
+  });
+
+  describe('writeSync', () => {
+    it('should write file with default formatting', () => {
+      const ph = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable);
+      ph.writeSync();
+
+      const expectedContent = `export type PathType = ${iterable.map((path) => `'${path}'`).join(' | ')}`;
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        OUTPUT_FILE_PATH,
+        expectedContent,
+      );
+    });
+
+    it('should write file with custom formatter', () => {
+      const formatter = (code: string) => code.toLowerCase();
+
+      new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable).write(formatter);
+
+      const expectedContent = `export type PathType = ${iterable
+        .map((path) => `'${path}'`)
+        .join(' | ')
+        .toLowerCase()}`;
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        OUTPUT_FILE_PATH,
+        expectedContent,
+      );
+    });
+
+    it('should return Ph class after writeSync', () => {
+      const ph = new Ph(
+        INPUT_DIRECTORY_PATH,
+        OUTPUT_FILE_PATH,
+        iterable,
+      ).writeSync();
+
+      expect(ph instanceof Ph).toBeTruthy();
     });
   });
 });

--- a/src/__internal__/__tests__/Ph.test.ts
+++ b/src/__internal__/__tests__/Ph.test.ts
@@ -117,7 +117,7 @@ describe('Ph', () => {
 
       expect(operations).toHaveLength(0);
 
-      ph.createUnionType();
+      ph._createUnionType();
 
       expect(operations).toEqual([
         'filter: path1',
@@ -134,7 +134,7 @@ describe('Ph', () => {
         INPUT_DIRECTORY_PATH,
         OUTPUT_FILE_PATH,
         iterable,
-      ).createUnionType();
+      )._createUnionType();
 
       const expectedContent = `export type PathType = ${iterable
         .map((path) => `'${path}'`)
@@ -146,7 +146,7 @@ describe('Ph', () => {
     it('should handle path mapping without typed function', () => {
       const code = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable)
         .map((path) => path)
-        .createUnionType();
+        ._createUnionType();
 
       const expectedContent = `export type PathType = ${iterable
         .map((path) => `'${path}'`)
@@ -158,7 +158,7 @@ describe('Ph', () => {
     it('should handle path mapping with typed function', () => {
       const code = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable)
         .map((path) => typed`${path}`)
-        .createUnionType();
+        ._createUnionType();
 
       const expectedContent = `export type PathType = ${iterable
         .map((path) => `'${path}'`)
@@ -171,7 +171,7 @@ describe('Ph', () => {
       const code = new Ph(INPUT_DIRECTORY_PATH, OUTPUT_FILE_PATH, iterable)
         .map((path) => path.toLocaleLowerCase())
         .map((path) => `${path}`)
-        .createUnionType();
+        ._createUnionType();
 
       const expectedContent = `export type PathType = ${iterable
         .map((path) => path.toLocaleLowerCase())

--- a/src/__internal__/__tests__/getAllFiles.test.ts
+++ b/src/__internal__/__tests__/getAllFiles.test.ts
@@ -4,14 +4,14 @@ import { getAllFiles } from '../getAllFiles';
 describe('getAllFiles', () => {
   it('one file', () => {
     const DIRECTORY_PATH = './src/__internal__/__tests__/__assets__/bar';
-    const res = getAllFiles(DIRECTORY_PATH);
+    const first = getAllFiles(DIRECTORY_PATH).next().value;
 
-    expect(res[0]).toBe(`${DIRECTORY_PATH}/index.ts`);
+    expect(first).toBe(`${DIRECTORY_PATH}/index.ts`);
   });
 
   it('recursive files', () => {
     const DIRECTORY_PATH = './src/__internal__/__tests__/__assets__';
-    const res = getAllFiles(DIRECTORY_PATH);
+    const res = [...getAllFiles(DIRECTORY_PATH)];
 
     expect(res.length).toBe(3);
   });

--- a/src/__internal__/__tests__/schemaParser.test.ts
+++ b/src/__internal__/__tests__/schemaParser.test.ts
@@ -8,7 +8,7 @@ describe('schemaParser', () => {
   it('should convert schema to ts', async () => {
     const INPUT_DIRECTORY_PATH = './src/__internal__/__tests__/__assets__/bar';
 
-    const schema = pathToSchema(getAllFiles(INPUT_DIRECTORY_PATH));
+    const schema = pathToSchema([...getAllFiles(INPUT_DIRECTORY_PATH)]);
     const ts = await schemaParser(schema);
 
     const expectedFile = `/* eslint-disable */

--- a/src/__internal__/__tests__/typed.test.ts
+++ b/src/__internal__/__tests__/typed.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { TS_TYPES, typed } from '../typed';
+
+describe('typed', () => {
+  it('should handle literal types', () => {
+    const asset = './src/foo.ts';
+    const res = typed`${asset}`.toCode();
+
+    expect(res).toBe(`'${asset}'`);
+  });
+
+  it('should handle object types', () => {
+    const asset = './src/foo.ts';
+    const params = `{
+      /** 
+      * @summary JSDoc test
+      */
+      path: ${asset},
+      params: {
+        a: string,
+        b: number
+      }
+    }`;
+
+    const res = typed`${params}`.toCode();
+
+    expect(res).toBe(params);
+  });
+
+  it('should expose TypeScript types as is', () => {
+    for (const type of TS_TYPES) {
+      expect(typed`${type}`.toCode()).toBe(type);
+    }
+  });
+});

--- a/src/__internal__/__tests__/typed.test.ts
+++ b/src/__internal__/__tests__/typed.test.ts
@@ -32,4 +32,13 @@ describe('typed', () => {
       expect(typed`${type}`.toCode()).toBe(type);
     }
   });
+
+  it('should preserve whitespace and newlines', () => {
+    const res = typed`
+      ${'value'}
+    `.toCode();
+    expect(res).toBe(`
+      'value'
+    `);
+  });
 });

--- a/src/__internal__/iterableHelpers.ts
+++ b/src/__internal__/iterableHelpers.ts
@@ -36,3 +36,8 @@ export function join<A>(separator: string, iterable: Iterable<A>): string {
 
   return res;
 }
+
+export const isIterable = (value: unknown): value is Iterable<unknown> => {
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  return typeof (value as any)[Symbol.iterator] === 'function';
+};

--- a/src/__internal__/iterableHelpers.ts
+++ b/src/__internal__/iterableHelpers.ts
@@ -1,0 +1,38 @@
+export function* map<A, B>(
+  f: (a: A) => B,
+  iterable: Iterable<A>,
+): IterableIterator<B> {
+  for (const a of iterable) {
+    yield f(a);
+  }
+}
+
+export function* filter<A>(f: (a: A) => boolean, iterable: Iterable<A>) {
+  for (const a of iterable) {
+    if (f(a)) {
+      yield a;
+    }
+  }
+}
+
+export function join<A>(separator: string, iterable: Iterable<A>): string {
+  const iterator = iterable[Symbol.iterator]();
+  const first = iterator.next();
+
+  if (first.done) {
+    return '';
+  }
+
+  let res = `${first.value}`;
+
+  while (true) {
+    const { value, done } = iterator.next();
+
+    if (done) {
+      break;
+    }
+    res = `${res}${separator}${value}`;
+  }
+
+  return res;
+}

--- a/src/__internal__/typed.ts
+++ b/src/__internal__/typed.ts
@@ -22,39 +22,30 @@ class Typed {
   ) {}
 
   toCode() {
-    const result: string[] = [];
+    const newValues = [...this.values, null];
+    const ziped = newValues.map((value, i) => [this.strs[i], value]);
 
-    for (let i = 0; i < this.values.length; i++) {
-      const str = this.strs[i]!;
-      const value = this.values[i];
+    return ziped
+      .flatMap(([str, value]) => {
+        // Handle TypeScript primitive types
+        if (typeof value === 'string' && TS_TYPES.has(value)) {
+          return [str, value];
+        }
 
-      result.push(str);
+        // Handle object types
+        if (typeof value === 'string' && value.includes('{')) {
+          return [str, value];
+        }
 
-      // Handle TypeScript primitive types
-      if (typeof value === 'string' && TS_TYPES.has(value)) {
-        result.push(value);
-        continue;
-      }
+        // Handle string literal types
+        if (typeof value === 'string') {
+          return [str, `'${value}'`];
+        }
 
-      // Handle object types
-      if (typeof value === 'string' && value.includes('{')) {
-        result.push(value);
-        continue;
-      }
-
-      // Handle string literal types
-      if (typeof value === 'string') {
-        result.push(`'${value}'`);
-        continue;
-      }
-
-      result.push(`${value}`);
-    }
-
-    // Add the final string part
-    result.push(this.strs[this.strs.length - 1]!);
-
-    return result.join('');
+        return [str, `${value}`];
+      })
+      .slice(0, -1)
+      .join('');
   }
 }
 

--- a/src/__internal__/typed.ts
+++ b/src/__internal__/typed.ts
@@ -49,13 +49,23 @@ class Typed {
   }
 }
 
+/**
+ * A tagged template function that converts template literals into TypeScript type expressions.
+ *
+ * @example
+ * // Primitive TypeScript types are preserved as-is
+ * typed`${'string'}` -> string
+ *
+ * // Regular strings are wrapped in quotes as literal types
+ * typed`${'./src/foo.ts'}` -> './src/foo.ts'
+ *
+ * // Object types are preserved in their original form
+ * typed`{ path: string }` -> { path: string }
+ */
 export const typed = (
   strs: TemplateStringsArray,
   ...values: unknown[]
-): Typed => {
-  return new Typed(strs, values);
-};
+): Typed => new Typed(strs, values);
 
-export const isTyped = (value: unknown): value is Typed => {
-  return value instanceof Typed;
-};
+export const isTyped = (value: unknown): value is Typed =>
+  value instanceof Typed;

--- a/src/__internal__/typed.ts
+++ b/src/__internal__/typed.ts
@@ -1,0 +1,70 @@
+export const TS_TYPES = new Set([
+  'string',
+  'number',
+  'boolean',
+  'any',
+  'unknown',
+  'never',
+  'void',
+  'null',
+  'undefined',
+  'object',
+  'bigint',
+  'symbol',
+  'true',
+  'false',
+]);
+
+class Typed {
+  constructor(
+    private strs: TemplateStringsArray,
+    private values: unknown[],
+  ) {}
+
+  toCode() {
+    const result: string[] = [];
+
+    for (let i = 0; i < this.values.length; i++) {
+      const str = this.strs[i]!;
+      const value = this.values[i];
+
+      result.push(str);
+
+      // Handle TypeScript primitive types
+      if (typeof value === 'string' && TS_TYPES.has(value)) {
+        result.push(value);
+        continue;
+      }
+
+      // Handle object types
+      if (typeof value === 'string' && value.includes('{')) {
+        result.push(value);
+        continue;
+      }
+
+      // Handle string literal types
+      if (typeof value === 'string') {
+        result.push(`'${value}'`);
+        continue;
+      }
+
+      result.push(`${value}`);
+    }
+
+    // Add the final string part
+    result.push(this.strs[this.strs.length - 1]!);
+
+    return result.join('');
+  }
+}
+
+export const typed = (
+  strs: TemplateStringsArray,
+  ...values: unknown[]
+): Typed => {
+  return new Typed(strs, values);
+};
+
+export const isTyped = (value: unknown): value is Typed => {
+  return value instanceof Typed;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { writeTS } from './writeTS';
-
+export { typed } from './typed';
 export type { CLIOptions } from './runCLI';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+import { ph } from './ph';
+
 export { writeTS } from './writeTS';
 export { typed } from './typed';
+export type { PathGen } from './__internal__/Ph';
 export type { CLIOptions } from './runCLI';
+
+export default ph;

--- a/src/ph.ts
+++ b/src/ph.ts
@@ -1,5 +1,11 @@
 import { type PathGen, Ph } from './__internal__/Ph';
 import { getAllFiles } from './__internal__/getAllFiles';
 
+/**
+ * Helps handle file paths flexibly through a chainable API. Uses method chaining with `map()`
+ * and `filter()` for path transformations. All operations are **lazily evaluated** until `write()` is called.
+ * @param inputPath Directory path to generate types from (e.g. './public/assets')
+ * @param outputPath File path where generated type definition will be written (e.g. './types/paths.ts')
+ */
 export const ph = (inputPath: string, outputPath: string): PathGen<string> =>
   new Ph(inputPath, outputPath, getAllFiles(inputPath));

--- a/src/ph.ts
+++ b/src/ph.ts
@@ -1,0 +1,5 @@
+import { type PathGen, Ph } from './__internal__/Ph';
+import { getAllFiles } from './__internal__/getAllFiles';
+
+export const ph = (inputPath: string, outputPath: string): PathGen<string> =>
+  new Ph(inputPath, outputPath, getAllFiles(inputPath));

--- a/src/typed.ts
+++ b/src/typed.ts
@@ -1,0 +1,1 @@
+export { typed } from './__internal__/typed';

--- a/src/writeTS.ts
+++ b/src/writeTS.ts
@@ -9,7 +9,7 @@ export const writeTS = async (
   options?: Omit<Options, 'space'>,
 ) => {
   const allFiles = getAllFiles(inputPath);
-  const schema = pathToSchema(allFiles, options);
+  const schema = pathToSchema([...allFiles], options);
 
   const res = await schemaParser(schema);
 


### PR DESCRIPTION
Closes #10 

### Changes made:
- [refactor(getAllFiles.ts): change to generator](https://github.com/SaeWooKKang/path-typegen/commit/4a426c96877075ae381dae77d0a65d0da045dc21)
- [feat(iterableHelpers.ts): create iterable helpers(map, filter, join)](https://github.com/SaeWooKKang/path-typegen/commit/48f84f0706a7f6812b207da37a2bb88488c2a66f)
- impl `ph` function
  - Helps handle file paths flexibly through a chainable API
  - `map` and `filter` are lazily evaluated until `write()` is called
  - can chaining 
    - map, filter, setConfig, setInputPath, setOutputPath, writeSync
  - can't chaining
    - write   
- impl `typed` tagged template function
  - converts template literals into TypeScript type expressions 
